### PR TITLE
Update the CFP date to match with Pretalx

### DIFF
--- a/content/ghent2025/posts/cfpopen.md
+++ b/content/ghent2025/posts/cfpopen.md
@@ -7,7 +7,7 @@ draft: false
 We're looking for _content_ for CfgMgmtCamp 2025 in Ghent, Belgium.
 
 We're looking for __presentations, workshops, fringes__.  
-The CfP will run untill __2024-10-20 23:55 CET__.  
+The CfP will run untill __2024-11-15 23:59 CET__.  
 Please remember to submit soon and often.  
 
 [https://cfp.cfgmgmtcamp.be/ghent2025/cfp](https://cfp.cfgmgmtcamp.be/ghent2025/cfp)


### PR DESCRIPTION
There is a mis match between the date on the website and the date on Pretalx. This PR aligns the two to the date mentioned on Pretalx.