### PR TITLE
Add beginner's guide as a reusable page

### DIFF
--- a/config/_default/menus.ghent2025.toml
+++ b/config/_default/menus.ghent2025.toml
@@ -51,6 +51,11 @@
 	url = "/ghent2025/codeofconduct/"
 	weight = -300
 [[navbar]]
+		name = "Guide"
+		identifier = "guide"
+		url = "/ghent2025/guide/"
+		weight = -200
+[[navbar]]
 	name = "Online Shop"
 	identifier = "shop"
 	url = "https://shop.cfgmgmtcamp.org/"

--- a/content/ghent2025/guide.md
+++ b/content/ghent2025/guide.md
@@ -1,0 +1,229 @@
+---
+title: "The Beginner’s Guide to CfgMgmtCamp"
+date: 2024-12-16
+draft: false
+---
+
+# The Beginner’s Guide to CfgMgmtCamp
+
+CfgMgmtCamp is one of the longest running OSS focused DevOps conferences in the
+world. Many of the luminaries in our field cut their DevOps teeth in Ghent and
+it’s still going strong. You’ll learn so much here and make so many new exciting
+friends and spark so many ideas.
+
+But it’s community volunteer organized, free, and low budget so you may not find
+all the amenities you’re expecting from the big-budget conferences. There’s no
+concierge desk, no AI driven venue map app on your phone, not even any Ice Cube
+concerts.
+
+Instead, you’ll find an information and idea rich environment and lots of
+opportunity to engage. This guide is intended to help lower some of the
+logistical friction, so that you can focus on learning.
+
+
+1. **Getting there**
+
+    The easiest way to get to Ghent is to fly to Brussels and take the train. Head
+    down to baggage claim and you’ll find vending machines where you can purchase
+    your train ticket to the **Gent-Sint-Pieters** station. From there, see #3 for
+    local transportation.
+
+    Do not assume that you can stay in Brussels and commute to Ghent. You’ll spend a
+    lot of time on the train and you’ll miss all the social events.
+
+    1. **Coming from Fosdem**
+
+        If you’re coming from Fosdem and are traveling light, then you may be interested
+        in carpooling instead of the train. Please reach out to Kris Buytaert for more
+        information and coordination.
+
+1. **Where to stay**
+
+    Don’t look for a place by the conference. Ghent city center is where most
+    extracurricular activity will occur and it’s not far. Many people stay at either
+    the [Novotel](https://all.accor.com/ssr/app/accor/rates/0840/index.en.shtml) or
+    the [NH](https://www.nh-hotels.com/en/hotel/nh-collection-gent), but there are
+    plenty of other options nearby.
+
+1. **Local transportation on the tram or bus**
+
+    [Public transit in Ghent](https://visit.gent.be/en/good-know/practical-information/getting-around/public-transport-ghent)
+    is quite navigable. The easiest way to get around is via contactless with your
+    phone or card. Just tap on the white terminal each time you enter a bus or tram.
+    You’ll be charged (€2.50) only once for an hour.
+
+    You can also buy a pack of 10 tickets at the ***Lijnwinkel*** inside the
+    Gent-Sint-Pieters or Korenmarkt stations or at a machine at many tram or bus
+    stops.
+
+    If you’re planning to stay extra and sightsee, you might consider a
+    [CityCard Ghent](https://visit.gent.be/en/good-know/practical-information/citycard-gent).
+    One reasonable price to get unlimited local transportation and entrance to
+    attractions, monuments, museums, and other sights. The local city bus is fairly
+    extensive and will take you even to other nearby cities, like Bruges.
+
+1. **The venue: *HoGhent SchoonMeersen***
+
+    1. **Finding your way around.**
+
+        Take the tram in from city center to the HoGhent SchoonMeersen campus. Don’t
+        expect to see a lot of signage directing you though. This is a volunteer run
+        conference without big marketing budgets. There won’t be a lot of students
+        around at this time, so if you see groups of people carrying laptops, they’re
+        probably a good bet to follow. This [Google maps link](https://maps.app.goo.gl/STnKypnvg1btZP947)
+        will take you directly to the front door of the conference lobby, where
+        you’ll see vendor tables, coffee, pastries, etc.
+
+        The conference is primarily in the *B* building. The main bathrooms are on the
+        ground floor, through the large doors to the left. Other bathrooms will
+        alternate genders on each of the floors. Several conference rooms are also on
+        the ground floor. Many are on upper floors, you’ll find the elevator and stairs
+        to the right. The rooms are coded as `<Building>.<Floor>.<Room>`. In
+        other words, *B.3.039* is building *B*, third floor, room *39*.
+
+    1. **Paying attention to the schedule and following updates**
+
+        Wifi access will be shared during the conference introduction in the *D auditorium*.
+        You’ll want this for the schedule and other such, but please don’t abuse it.
+
+        [Open the schedule](https://cfp.cfgmgmtcamp.org/2025/schedule/) on your phone
+        and/or laptop. Plan ahead which talks, or tracks, or speakers you’re excited to
+        see and figure out where the rooms are. Then pay attention around you. If
+        schedule changes are required, such as running 15 minutes behind or the like,
+        they won’t be announced over a loudspeaker. Instead, you’ll overhear it or see
+        crowds of people start moving. Don’t hesitate to ask someone what’s going on.
+        We’re all helping each other out.
+
+    1. **The common area and hallway track**
+
+        The lobby is where vendors will have their tables set up. There will be coffee,
+        fruits, pastries, and such. And there will be a lot of people excited to talk to
+        each other. This is where most of the hallway track happens. When you’re done
+        with a talk and you don’t have anything in particular to do, you should come
+        here. If you are in the lobby and it seems particularly empty, then there’s
+        probably a talk happening. If you didn’t expect that, ask someone. There may
+        have been a schedule change that didn’t get published.
+
+    1. **Swag pickup**
+
+        Walter will have to do this section 😀
+
+    1. **Front and back entrances to the main stage**
+
+        The keynotes are in the *D auditorium*, which is directly across the courtyard
+        from the lobby. You can either enter the ground floor door which takes you in by
+        the front stage, or you can go up the stairs and enter from the back. If you’re
+        late to a talk, please enter from the back.
+
+    1. **Overflow rooms**
+
+        *B.Con* is the ground floor auditorium across from the bathrooms. This room has
+        talks but is also the overflow room for streamed keynotes when *D.Aud* is full.
+
+    1. **How lunch and other food works**
+
+        Lunch is in the cafeteria in the D building just past the auditorium down the
+        large open-air walkway between the buildings. You’ll likely see a long line
+        gathering, but it moves fairly quickly. Lunch is cafeteria style; pick what you
+        want and pay at the register.
+
+        Breakfast pastries are available in the conference lobby each morning. It’s not
+        much, so if you’re big on breakfast then you probably want to eat before you
+        head in.
+
+        Sometimes if we’re lucky a magic waffle truck shows up on the second day with
+        delicious free Belgian waffles. Keep an eye out near the sponsor booths and
+        listen to the chatter!
+
+    1. **Lost and found or emergencies**
+
+        If you lose or find something or have other emergencies, please go to the
+        counter in the lobby.
+
+    1. **Getting help from a coordinator**
+
+        There are quite a few coordinators and they’re recognizable enough that you can
+        just start asking attendees if they’ve seen various people. For conference
+        logistics and scheduling, ask for ***Toshaan*** or ***Kris***. For venue and room questions
+        ask for ***Bert***. Otherwise just ask if anyone has seen a coordinator.
+
+1. **After the talks**
+
+    1. **The official social event**
+
+        There is a social event Monday night after the conference directly across the
+        street at [the Zone](https://www.thezone.be/the-zone-cafe/). Before you leave
+        the conference, you should get a wristband. Many of the vendor booths will be
+        handing them out but there will also be folks wandering around with them. This
+        wristband will buy your drinks.
+
+    1. **Peer networking and nightlife**
+
+        Ghent is a wonderful place with [a rich nightlife](https://visit.gent.be/en/eat-drink).
+        Make some friends and have dinner or meet for drinks. Some of the conference favorites include
+
+        * Trollekelder bar
+        * Waterhuis bar
+        * 't Dreupelkot genever bar next door to the Waterhuis. Just don’t spill the genever!
+        * Gruut brewery, especially if you’ve never tried gruut
+        * Comic Sans pinball arcade
+        * Amadeus rib house. Note that there are two, make sure you know which one you’re meeting at!
+        * [Lots and lots more](https://visit.gent.be/en/eat-drink)!
+
+1. **The fringe workshops**
+
+    The third day of the conference is not centrally organized. Instead, different
+    groups use the space to run their own workshops or “mini conferences” attached
+    to the main venue. For example, there will be a Foreman hack day, Community Day
+    events for both Puppet and Ansible, an [mgmtconfig](https://github.com/purpleidea/mgmt)
+    workshop, and many more.
+
+    The same rules about lunch and all apply, but there will be no central organization.
+    Instead, follow the schedules of the fringe events you’re attending.
+
+    Please try to register ahead for the fringe events so we can plan for the right
+    sized rooms. But don’t let it stop you if you forget or you discover an event
+    you really want to attend. We want you to get the most out of this you can.
+
+    If we do have to reorganize rooms, there will be a sign taped to the original
+    room telling you where to go.
+
+1. **Social media**
+
+    1. **Who to follow**
+        1. [https://fosstodon.org/@cfgmgmtcamp](https://fosstodon.org/@cfgmgmtcamp)
+        1. [https://bsky.app/profile/cfgmgmtcamp.bsky.social](https://bsky.app/profile/cfgmgmtcamp.bsky.social)
+        1. The hashtag `#cfgmgmtcamp` on your social platform of choice.
+
+    1. **Posting and promoting**
+
+        We love when you promote us and tell the world what amazing fun they’re missing
+        out on. Share what you’re learning, inspirations you’re having, the sights
+        you’re seeing. Share tips for other conference attendees like “it’s time, the
+        waffles are here!” Use the hashtag `#cfgmgmtcamp` and/or `#ghent`.
+
+        If something’s going wrong, or you want to give feedback then it’s probably more
+        expedient to find one of the coordinators to speak with!
+
+1. **Afterwards**
+
+    1. **Write down your ideas and build something cool**
+
+        You just absorbed an utter firehose of information. Right now, it’s all bouncing
+        around in your head, but if you want to truly learn or take action on something
+        you saw then you should write it down before it escapes you. Take notes or
+        journal. Make a note of the people you met who you’d like to follow up with.
+
+        If work paid for the trip, it’s especially important to write up some kind of
+        trip report even if you weren’t asked to do so. This will help them see the
+        value of the trip and document all the actionable results that came from it. And
+        then next year, it’s more likely that your trip request will be approved and we
+        can see you again!
+
+    1. **Plan ahead to submit a talk for next year**
+
+        And speaking of next year, you probably saw a few talks that you could have
+        given. Or maybe something similar. See, the people up there speaking are just
+        like you. And you have ideas that you can share too. So write some of them down
+        while you’re feeling inspired and make a note in your calendar to submit a talk
+        when our CFP comes back around.


### PR DESCRIPTION
This also adds it to the navbar, I'm assuming that's where we want it
linked. If it's too busy, we could probably turn off the CFP link for
now?
