### PR TITLE
Refactored & styled the bottom footer

### DIFF
--- a/themes/cfgmgmtcamp/assets/css/stylesheet.css
+++ b/themes/cfgmgmtcamp/assets/css/stylesheet.css
@@ -565,25 +565,20 @@ footer {
   border-top: 10px solid #5782ad;
   color: #aaaaaa;
   background: #ffffff;
-  opacity: 75%;
   font-size: 10px;
+  display: flex;
+  justify-content: space-between;
 }
 footer div {
   display: inline-block;
 }
 #leftsponsor {
-  width: 25%;
-  float: left;
   text-align: left;
 }
 #centertext {
-  width: 35%;
-  float: center;
   text-align: center;
 }
 #rightsponsor {
-  width: 25%;
-  float: right;
   text-align: right;
 }
 
@@ -799,7 +794,8 @@ footer {
   border-top: 10px solid #5782ad;
   color: #aaaaaa;
   background: #ffffff;
-  opacity: 100%;
+  display: flex;
+  justify-content: space-between;
 }
 footer div {
   width: 100%;
@@ -808,18 +804,12 @@ footer div {
   display: inline-block;
 }
 #leftsponsor {
-  width: 25%;
-  float: left;
   text-align: left;
 }
 #centertext {
-  width: 35%;
-  float: center;
   text-align: center;
 }
 #rightsponsor {
-  width: 25%;
-  float: right;
   text-align: right;
 }
 #rightsponsor img {

--- a/themes/cfgmgmtcamp/static/css/stylesheet.css
+++ b/themes/cfgmgmtcamp/static/css/stylesheet.css
@@ -431,7 +431,6 @@ footer {
   border-top: 10px solid #5782ad;
   color: #aaaaaa;
   background: #ffffff;
-  opacity: 75%;
 }
 footer div {
   width: 100%;
@@ -645,7 +644,6 @@ footer {
   border-top: 10px solid #5782ad;
   color: #aaaaaa;
   background: #ffffff;
-  opacity: 75%;
 }
 footer div {
   width: 100%;


### PR DESCRIPTION
This removes the opacity and switches to flexbox layout. That means that
instead of us having to manually size things and float them left and
right, the browser will just space them out as fits.

The immediate consequence is that all of the text in the center is
visible and readable again.