### PR TITLE
Adds a small logo for betadots/media

### DIFF
--- a/content/ghent2026/sponsors/betadots2.md
+++ b/content/ghent2026/sponsors/betadots2.md
@@ -1,0 +1,8 @@
+---
+title: "betadots"
+level: media
+image: betadots.png
+link: https://www.betadots.de/
+date: 2026-01-08
+draft: false
+---


### PR DESCRIPTION
Betadots paid their graphic designers to create the tshirt logo. Even
though we ultimately didn't use it, I think it's fair to give them
recognition for it.
