### PR TITLE
Correct dates for cfp 2027

### DIFF
--- a/content/ghent2027/posts/cfpopen.md
+++ b/content/ghent2027/posts/cfpopen.md
@@ -1,16 +1,16 @@
  ---
-title: "CfgMgmtCamp 2026 Call for Presentation is OPEN"
+title: "CfgMgmtCamp 2027 Call for Presentation is OPEN"
 date: 2026-07-22
 draft: false
 ---
 
-We're looking for _content_ for CfgMgmtCamp 2026 in Ghent, Belgium.
+We're looking for _content_ for CfgMgmtCamp 2027 in Ghent, Belgium.
 
 We're looking for __presentations, workshops, fringes__.  
-The CfP will run untill __20256-09-20 23:59 CET__.  
+The CfP will run until __2026-09-20 23:59 CET__.  
 Please remember to submit soon and often.  
 
-[https://cfp.cfgmgmtcamp.org/ghent2026/cfp](https://cfp.cfgmgmtcamp.org/ghent2027/cfp)
+[https://cfp.cfgmgmtcamp.org/ghent2027/cfp](https://cfp.cfgmgmtcamp.org/ghent2027/cfp)
 
 
 If you're female, underrepresented, newcomer, or just want some help, feel free to reach out privately to our team members who are happy to help you with your talk proposal!  


### PR DESCRIPTION
__Correct dates in CfP 2027__

There were some issues with that, still referencing cfgmgmtcamp 2026. I have corrected them here.

## Types of content changes

* Spelling mistake
