### PR TITLE
Add reference to website sources on GitHub

### DIFF
--- a/themes/cfgmgmtcamp/layouts/partials/footer.html
+++ b/themes/cfgmgmtcamp/layouts/partials/footer.html
@@ -8,8 +8,9 @@
 		CfgMgmtCamp is a free open source event. CfgMgmtCamp logo is property of the CfgMgmtCamp group.<br>
 		Copyleft 2014 - {{ now.Year }}, CfgMgmtCamp.<br>
 		{{ if .GitInfo }}
-			Git {{ .GitInfo.AbbreviatedHash }}
+			Git {{ .GitInfo.AbbreviatedHash }}.
 		{{ end }}
+    <a href="https://github.com/cfgmgmtcamp/www_cfgmgmtcamp" target="_blank">View sources on GitHub</a>
 		<br>
 	</div>
 	<div id="rightsponsor">


### PR DESCRIPTION
__Add reference to website sources on GitHub__

I found an issue in this website (which I have created a separate PR for). I saw that a git commit was referenced, but didn't know that the website was open source (or where to find it). I was hinted to that via Matrix. For the next person to stumble upon something like that I'd like them to find the link easier than me.

## Types of content changes

* Layout improvement
